### PR TITLE
Changed the username for RKE SSH to match the username in hosts.yml

### DIFF
--- a/roles/kubernetes/templates/cluster.yml.j2
+++ b/roles/kubernetes/templates/cluster.yml.j2
@@ -9,7 +9,7 @@ nodes:
       - worker
       - etcd
     hostname_override: ""
-    user: ubuntu
+    user: {{ ansible_user }}
     docker_socket: /var/run/docker.sock
     ssh_key: ""
     ssh_key_path: {{ ansible_env.HOME }}/{{ magma_directory }}/.ssh/id_rsa


### PR DESCRIPTION
I got RKE SSH Error when I tried to run the ansible-playbook, same error as RKE Issue #3 
I had to manually change it in the template file to match the username of the target node.
This should fix it.